### PR TITLE
Readme rendering dev shm

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ Chromium is used as a rendering engine for Looker. Chromium stores temporary fil
   name: dshm
 ```
 
+Alternatively, the shm size can be specified as a runtime argument:
+
+```
+--shm-size=1g
+```
+
 ## Useful Stuff
 
 When you have gone through several updates of the Docker image, the old images build up

--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ docker stop b9346ff139c4
 
 # Misc
 
+## Rendering 
+
+Chromium is used as a rendering engine for Looker. Chromium stores temporary files/cache inside the /dev/shm folder. By default, Docker only provisions 64 MB for the /dev mount point. If you are running into rendering issues, particularly for large dashboards or PNG/Visualization formats, it may be due to the limited space available in that folder. The solution is to create a new volume in memory and mount /dev/shm 
+
+```
+- emptyDir:
+    medium: Memory
+  name: dshm
+```
+
 ## Useful Stuff
 
 When you have gone through several updates of the Docker image, the old images build up


### PR DESCRIPTION
By default, Docker allocated 64M to /dev/shm, which can lead to rendering issues. Updated README to give two solutions to this

1. Mount /dev/shm in memory
2. Pass runtime argument --shm-size=1g